### PR TITLE
DOCKER-523 Allow parent snapshot to use a full snapshot path.

### DIFF
--- a/cmd.c
+++ b/cmd.c
@@ -113,6 +113,12 @@ make_fullsnap(const char *dataset, const char *snap, char **fullsnap)
 	VERIFY(dataset != NULL);
 	VERIFY(snap != NULL);
 
+	if (strchr(snap, '@') != NULL) {
+		// It's already a full snapshot.
+		*fullsnap = strdup(snap);
+		return (0);
+	}
+
 	if (strchr(dataset, '@') != NULL || strchr(snap, '@') != NULL) {
 		errno = EINVAL;
 		return (-1);


### PR DESCRIPTION
For docker commit (which creates an image from an existing container), I have the following:

```
 zone: /zones/3dfd8b8b-d213-4949-8577-f241e682229f
 image: zones/0bb89966-bd31-3b23-8635-f9edd4f5c236@final
 snap: zones/3dfd8b8b-d213-4949-8577-f241e682229f@snap1
```

The docker container (3dfd...) is based on the image (0bb8...), and I want to be able get the difference between the container snapshot `snap1` and the base image `zones/0bb8...@final`.

I modified zfs_snapshot as such, then using this command line I can generate the diff between them (and zfs diff is happy to do this):

```
zfs_snapshot_tar -r root zones/3dfd8b8b-d213-4949-8577-f241e682229f zones/0bb89966-bd31-3b23-8635-f9edd4f5c236@final snap1
```
